### PR TITLE
PR : sign-up validate checking

### DIFF
--- a/src/libs/yup/schema.ts
+++ b/src/libs/yup/schema.ts
@@ -13,3 +13,8 @@ export const passwordSchema = yup
   .matches(/\d/, "숫자를 포함해주세요.")
   .matches(/[!@#$%^&*()_+]/, "특수문자를 포함해주세요.")
   .required("비밀번호는 필수항목 입니다.")
+
+export const passwordConfirmSchema = yup
+  .string()
+  .oneOf([yup.ref("password")], "비밀번호가 일치하지 않습니다.")
+  .required("비밀번호를 다시 입력해 주세요.")

--- a/src/pages/sign/components/sign-in.form.tsx
+++ b/src/pages/sign/components/sign-in.form.tsx
@@ -7,7 +7,7 @@ import { OnSubmitFormFT } from "../sign.type"
 import { ErrorMsg } from "./error-msg"
 
 export const SignInForm = () => {
-  const { register, handleSubmit, errors } = useSignInForm()
+  const { register, handleSubmit, errors, isValid } = useSignInForm()
   const { mutate } = useMutationSignIn()
   const onSubmitForm: OnSubmitFormFT = (form) => mutate(form)
 
@@ -36,7 +36,9 @@ export const SignInForm = () => {
         />
         <ErrorMsg errorField={errors[FORM_PW]} />
       </div>
-      <Button type="submit">Login</Button>
+      <Button type="submit" disabled={!isValid}>
+        Login
+      </Button>
     </form>
   )
 }

--- a/src/pages/sign/components/sign-in.form.tsx
+++ b/src/pages/sign/components/sign-in.form.tsx
@@ -8,8 +8,8 @@ import { ErrorMsg } from "./error-msg"
 
 export const SignInForm = () => {
   const { register, handleSubmit, errors, isValid } = useSignInForm()
-  const { mutate } = useMutationSignIn()
-  const onSubmitForm: OnSubmitFormFT = (form) => mutate(form)
+  const { login } = useMutationSignIn()
+  const onSubmitForm: OnSubmitFormFT = (form) => login(form)
 
   return (
     <form

--- a/src/pages/sign/components/sign-up.form.tsx
+++ b/src/pages/sign/components/sign-up.form.tsx
@@ -1,48 +1,24 @@
-import { useDialog } from "@/components/dialog/dialog.hook"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { FORM_EMAIL, FORM_PW, FORM_PW_CONFIRM } from "@/constants"
 import { Label } from "@radix-ui/react-label"
 import { useMutationSignUp, useSignUpForm } from "../sign.hooks"
-import { SignUpFormType } from "../sign.type"
+import { OnSubmitFormFT } from "../sign.type"
 
 export const SignUpForm = () => {
   const { signUp } = useMutationSignUp()
   const { register, handleSubmit } = useSignUpForm()
-  const { onAlert } = useDialog()
-
-  const onSubmitSignInData = (data: SignUpFormType) => {
-    /** @notice yup schema 적용시, 👇 아래 분기 삭제 */
-    if (!!!data[FORM_EMAIL]) {
-      onAlert({
-        children: "이메일이 입력되지 않았습니다.",
-        onConfirm: () => {},
-      })
-      return
-    }
-    /** @notice yup schema 적용시, 👇 아래 분기 삭제 */
-    if (data[FORM_PW] !== data[FORM_PW_CONFIRM]) {
-      onAlert({
-        children: "비밀번호를 다시 확인해주세요.",
-        onConfirm: () => {},
-      })
-      return
-    }
-    signUp({
-      email: data.email,
-      password: data.password,
-    })
-  }
+  const onSubmitForm: OnSubmitFormFT = (form) => signUp(form)
 
   return (
     <form
       className="flex w-full flex-col gap-5 px-3"
-      onSubmit={handleSubmit(onSubmitSignInData)}
+      onSubmit={handleSubmit(onSubmitForm)}
     >
       <div className="grid w-full items-center gap-1.5">
         <Label>Email</Label>
         <Input
-          {...register("email")}
+          {...register(FORM_EMAIL)}
           type="email"
           placeholder="Email"
           autoComplete="off"
@@ -51,7 +27,7 @@ export const SignUpForm = () => {
       <div className="grid w-full items-center gap-1.5">
         <Label>Passoword</Label>
         <Input
-          {...register("password")}
+          {...register(FORM_PW)}
           type="password"
           placeholder="Password"
           autoComplete="off"
@@ -60,7 +36,7 @@ export const SignUpForm = () => {
       <div className="grid w-full items-center gap-1.5">
         <Label>Confirm Password</Label>
         <Input
-          {...register("password-confirm")}
+          {...register(FORM_PW_CONFIRM)}
           type="password"
           placeholder="Confirm Password"
           autoComplete="off"

--- a/src/pages/sign/components/sign-up.form.tsx
+++ b/src/pages/sign/components/sign-up.form.tsx
@@ -4,10 +4,11 @@ import { FORM_EMAIL, FORM_PW, FORM_PW_CONFIRM } from "@/constants"
 import { Label } from "@radix-ui/react-label"
 import { useMutationSignUp, useSignUpForm } from "../sign.hooks"
 import { OnSubmitFormFT } from "../sign.type"
+import { ErrorMsg } from "./error-msg"
 
 export const SignUpForm = () => {
   const { signUp } = useMutationSignUp()
-  const { register, handleSubmit } = useSignUpForm()
+  const { register, handleSubmit, errors } = useSignUpForm()
   const onSubmitForm: OnSubmitFormFT = (form) => signUp(form)
 
   return (
@@ -23,6 +24,7 @@ export const SignUpForm = () => {
           placeholder="Email"
           autoComplete="off"
         />
+        <ErrorMsg errorField={errors[FORM_EMAIL]} />
       </div>
       <div className="grid w-full items-center gap-1.5">
         <Label>Passoword</Label>
@@ -32,6 +34,7 @@ export const SignUpForm = () => {
           placeholder="Password"
           autoComplete="off"
         />
+        <ErrorMsg errorField={errors[FORM_PW]} />
       </div>
       <div className="grid w-full items-center gap-1.5">
         <Label>Confirm Password</Label>
@@ -41,6 +44,7 @@ export const SignUpForm = () => {
           placeholder="Confirm Password"
           autoComplete="off"
         />
+        <ErrorMsg errorField={errors[FORM_PW_CONFIRM]} />
       </div>
       <Button type="submit">Join Now</Button>
     </form>

--- a/src/pages/sign/components/sign-up.form.tsx
+++ b/src/pages/sign/components/sign-up.form.tsx
@@ -8,7 +8,7 @@ import { ErrorMsg } from "./error-msg"
 
 export const SignUpForm = () => {
   const { signUp } = useMutationSignUp()
-  const { register, handleSubmit, errors } = useSignUpForm()
+  const { register, handleSubmit, errors, isValid } = useSignUpForm()
   const onSubmitForm: OnSubmitFormFT = (form) => signUp(form)
 
   return (
@@ -46,7 +46,9 @@ export const SignUpForm = () => {
         />
         <ErrorMsg errorField={errors[FORM_PW_CONFIRM]} />
       </div>
-      <Button type="submit">Join Now</Button>
+      <Button type="submit" disabled={!isValid}>
+        Join Now
+      </Button>
     </form>
   )
 }

--- a/src/pages/sign/sign.hooks.ts
+++ b/src/pages/sign/sign.hooks.ts
@@ -29,7 +29,7 @@ export const useMutationSignIn = () => {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { onAlert } = useDialog()
-  return useMutation({
+  const { mutate: signIn, ...rest } = useMutation({
     mutationKey: [MUTATION_KEY_SIGN_IN],
     mutationFn: ({ email, password }: SignFormType) =>
       postUserSignIn({ email, password }),
@@ -41,6 +41,7 @@ export const useMutationSignIn = () => {
     },
     onError: (error) => onAlert({ children: error.message }),
   })
+  return { signIn, ...rest }
 }
 
 export const useSignUpForm = () => {
@@ -56,7 +57,7 @@ export const useSignUpForm = () => {
 }
 export const useMutationSignUp = () => {
   const { onAlert } = useDialog()
-  const { mutate: signUp } = useMutation({
+  const { mutate: signUp, ...rest } = useMutation({
     mutationKey: [MUTATION_KEY_SIGN_UP],
     mutationFn: (signForm: SignFormType) => postSignUp(signForm),
     onSuccess: () => {
@@ -65,5 +66,5 @@ export const useMutationSignUp = () => {
     },
     onError: (error) => onAlert({ children: error.message }),
   })
-  return { signUp }
+  return { signUp, ...rest }
 }

--- a/src/pages/sign/sign.hooks.ts
+++ b/src/pages/sign/sign.hooks.ts
@@ -11,7 +11,7 @@ import { useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
 import { postSignUp, postUserSignIn } from "./sign.func"
 import type { SignFormType, SignUpFormType } from "./sign.type"
-import { signInSchema } from "./sign.yup-schema"
+import { signInSchema, signUpSchema } from "./sign.yup-schema"
 
 export const useSignInForm = () => {
   const {
@@ -48,7 +48,10 @@ export const useSignUpForm = () => {
     register,
     handleSubmit,
     formState: { errors, isValid },
-  } = useForm<SignUpFormType>()
+  } = useForm<SignUpFormType>({
+    mode: "onChange",
+    resolver: yupResolver(signUpSchema),
+  })
   return { register, handleSubmit, errors, isValid }
 }
 export const useMutationSignUp = () => {

--- a/src/pages/sign/sign.yup-schema.ts
+++ b/src/pages/sign/sign.yup-schema.ts
@@ -1,8 +1,14 @@
-import { FORM_EMAIL, FORM_PW } from "@/constants"
-import { emailSchema, passwordSchema } from "@/libs/yup"
+import { FORM_EMAIL, FORM_PW, FORM_PW_CONFIRM } from "@/constants"
+import { emailSchema, passwordConfirmSchema, passwordSchema } from "@/libs/yup"
 import * as yup from "yup"
 
 export const signInSchema = yup.object().shape({
   [FORM_EMAIL]: emailSchema,
   [FORM_PW]: passwordSchema,
+})
+
+export const signUpSchema = yup.object().shape({
+  [FORM_EMAIL]: emailSchema,
+  [FORM_PW]: passwordSchema,
+  [FORM_PW_CONFIRM]: passwordConfirmSchema,
 })


### PR DESCRIPTION
## 🔥 Issues
<!-- [여기서부터 주석]

    - 관련된 issue 번호를 작성해주세요. (단, 아래 경우를 고려해서 큰 따옴표 안의 내용을 작성하면 됩니다.!)
    
      1) PR merge 된 후, 해당 issue 가 자동으로 "close" 되기 원한다면?
          => "- close #n" 
       
      2) PR merge 된 이후에도, 해당 issue 와 연관된 작업이 아직 남아있다면?
          => "- #n "

    
[여기까지 주석] -->

- close #71




<br/>
<br/>

## 🎯 작업 내용
<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)
    
        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.
        
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.
    
    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!
    
    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

- [feat : 회원가입 폼 유효성 검사 기능 추가](https://github.com/mobi-projects/mobi-3rd-1-typescript/commit/5559dc99f3166b4e8eec3e81747f30add10a9457)
  - 회원가입 시에 필요한 스키마 정의했습니다.
  - 정의된 위치나 방법은 이전 [로그인 유효성검사](https://github.com/mobi-projects/mobi-3rd-1-typescript/pull/81) 과 동일합니다. 🫠
 
- [feat : 회원가입 유효서 검사 중 에러 발생시, 메시지 출력](https://github.com/mobi-projects/mobi-3rd-1-typescript/commit/4158373f2bc04db52f3e9d4d41b376aae6b57cad)\
 

### 🖥️ 시연영상

https://github.com/mobi-projects/mobi-3rd-1-typescript/assets/50646145/218186ba-3a66-4ebe-a24e-a1662f76672a



<br>
<br>
<br>

----------


- [feat : 유효성 검사 충족 불가 시, 버튼 비활성화](https://github.com/mobi-projects/mobi-3rd-1-typescript/pull/90/commits/3362d232d7944e5801f643b2101b765b6215b098)
  - sign-in, sign-up 입력에 대해 유효성 검사 실패 시, 버튼이 비활성화 되도록 했습니다.  
  - useForm 에서 반환되는 속성 중, `isValid` 사용했습니다.

https://github.com/mobi-projects/mobi-3rd-1-typescript/assets/50646145/13fb7b1b-fda3-4aa9-82dd-cfa74157fc8f



<br>
<br>
<br>

----------

- [chore : mutate() alias, login](https://github.com/mobi-projects/mobi-3rd-1-typescript/pull/90/commits/367033c50b1f6e335a3b24f1acb3ef0149d28d6c)
  - `useMutation()` 을 기반으로 로그인 로직을 관리하는 `useMutationSignIn()` 의 반환 메서드 에 대해 작업했습니다.
  -  `mutate()` 라는 메서드의 이름을 `login()` 으로 변환하여 반환합니다.
  - 해당 메서드는 로그인 시 사용자의 입력을 받아, axios 호출 로직의 파라미터로 전달합니다.

```ts
export const useMutationSignIn = () => {
  const queryClient = useQueryClient()
  const navigate = useNavigate()
  const { onAlert } = useDialog()
  const { mutate: login, ...rest } = useMutation({ 
    mutationKey: [MUTATION_KEY_SIGN_IN],
    mutationFn: ({ email, password }: SignFormType) =>
      postUserSignIn({ email, password }),
    onSuccess: (data) => {
      const user = { ...data }
      onAlert({ children: `${user.nickname} 님, 환영합니다.` })
      queryClient.setQueryData([QUERY_KEY_USER], user)
      navigate(PATH_HOME)
    },
    onError: (error) => onAlert({ children: error.message }),
  })
  return { login, ...rest } // 👈 이전에는 mutate 이름으로 곧바로 반환되었습니다.
}
```

<br/>
<br/>

## ✅ 체크 리스트
<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.
    
    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!
    
    올바른 예)
    [x]
    
    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

-   [x] Main 브랜치 Pull 받기
-   [x] Issue 번호 설정 확인
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인




<br/>
<br/>

-----

#### 🙏 꼭 리뷰 남겨주세요.!!
- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
