### PR TITLE
PR : ui수정 요구사항반영해서 sign페이지 refactor

### DIFF
--- a/src/pages/sign/components/sign-in.form.tsx
+++ b/src/pages/sign/components/sign-in.form.tsx
@@ -12,7 +12,7 @@ export const SignInForm = () => {
 
   return (
     <form
-      className="flex w-full flex-col gap-5 px-3"
+      className="flex w-full flex-col gap-3 "
       onSubmit={handleSubmit(onSubmitForm)}
     >
       <LabeledInput
@@ -20,7 +20,7 @@ export const SignInForm = () => {
         label="Email"
         register={register}
       />
-      <ErrorMsg errorField={errors[FORM_EMAIL]} /> 
+      <ErrorMsg errorField={errors[FORM_EMAIL]} />
       <LabeledInput
         registerKey={FORM_PW}
         register={register}

--- a/src/pages/sign/components/sign-in.header.tsx
+++ b/src/pages/sign/components/sign-in.header.tsx
@@ -1,6 +1,6 @@
 export const SignInHeader = () => {
   return (
-    <div className="flex h-[13rem] w-full flex-col gap-3">
+    <div className="flex h-[10rem] w-full flex-col gap-3">
       <h1 className="text-4xl font-extrabold">Chaeg Check</h1>
       <h2 className=" text-xl font-semibold">
         Share your experiences of reading books here

--- a/src/pages/sign/components/sign-up.form.tsx
+++ b/src/pages/sign/components/sign-up.form.tsx
@@ -12,7 +12,7 @@ export const SignUpForm = () => {
 
   return (
     <form
-      className="flex w-full flex-col gap-5 px-3"
+      className="flex w-full flex-col gap-3"
       onSubmit={handleSubmit(onSubmitForm)}
     >
       <LabeledInput<SignUpFormType>

--- a/src/pages/sign/components/sign-up.header.tsx
+++ b/src/pages/sign/components/sign-up.header.tsx
@@ -1,6 +1,6 @@
 export const SignUpHeader = () => {
   return (
-    <div className="flex h-[14rem] w-full flex-col gap-3">
+    <div className="flex h-[10rem] w-full flex-col gap-3 ">
       <h1 className="text-4xl font-extrabold">Chaeg Check</h1>
       <h2 className=" text-xl font-semibold">
         Let's sign up and share our book reviews together

--- a/src/pages/sign/index.tsx
+++ b/src/pages/sign/index.tsx
@@ -10,16 +10,16 @@ import {
 export const Sign = () => {
   return (
     <div className="flex h-dvh w-full items-center justify-center">
-      <div className="IPAD_PRO:w-[52rem] IPAD_PRO:items-start IPAD_PRO:pt-28  flex h-full w-full  items-center justify-center pb-20">
-        <Tabs defaultValue={D_LOGIN} className="w-full px-2">
+      <div className="flex h-full w-full items-center justify-center IPAD_PRO:w-[40rem]">
+        <Tabs defaultValue={D_LOGIN} className="h-[40rem] w-full px-4">
           <TabsContent value={D_LOGIN}>
             <SignInHeader />
           </TabsContent>
           <TabsContent value={D_SIGN_UP}>
             <SignUpHeader />
           </TabsContent>
-          <TabsList className="dark w-full ">
-            <TabsTrigger value={D_LOGIN} className="w-full">
+          <TabsList className="dark w-full mb-4">
+            <TabsTrigger value={D_LOGIN} className="w-full ">
               Login
             </TabsTrigger>
             <TabsTrigger value={D_SIGN_UP} className="w-full ">


### PR DESCRIPTION
## 🔥 Issues
<!-- [여기서부터 주석]

    - 관련된 issue 번호를 작성해주세요. (단, 아래 경우를 고려해서 큰 따옴표 안의 내용을 작성하면 됩니다.!)
    
      1) PR merge 된 후, 해당 issue 가 자동으로 "close" 되기 원한다면?
          => "- close #n" 
       
      2) PR merge 된 이후에도, 해당 issue 와 연관된 작업이 아직 남아있다면?
          => "- #n "

    
[여기까지 주석] -->

- #93 




<br/>
<br/>

## 🎯 작업 내용
<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)
    
        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.
        
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.
    
    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!
    
    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->
- [refactor : ui수정 요구사항반영해서 sign페이지 refactor](https://github.com/mobi-projects/mobi-3rd-1-typescript/commit/dc42791f762da2cbdd6f0d89b117514c2730468c)
- 이전에 피드백받았던 ui관련 리펙터링을 진행했습니다. 수정한 내용은 다음과 같습니다.
### 이전에 존재했던 오류case
- <img width="405" height="300" alt="image" src="https://github.com/mobi-projects/mobi-3rd-1-typescript/assets/144839872/1fd47c00-2ee3-450b-80ca-1fda309c098b">
보시는 것처럼 header부분이 화면위로 넘어가는 문제가있었습니다.
### 원인이 무엇이죠? 🤷‍♂️
- 기존 구조에대해 먼저 설명드리면 
```ts
<div>                   // 화면의 정가운데 배치하기위해 className = "flex justify-center items-center"
 <div>                  // 여기서 문제가생겼어요!  
                      // ====> claseName = "flex  justfiy-center items-start" items-start를 설정해서문제발생
  <LoginTabs/>    // 입력받는 form컴포넌트 구성요소
 </div>
</div>
```
위와같이설정하고 `<LoginTabs>`부분에서 다른 css를 설정하니 다음과 같은 문제가 생기더라구요 
또한 지금설정은 `items-start`이기때문에 위에서부터 보여져야해서 이상적이지 않아요. 가운데 배치했으면 좋을것 같은데
### 어떻게 해결했나요?☝
- 이상적인 구조를 위해 `items-center`로 수정했습니다. 이를 통해 화면의 가운데 배치하는 것을 성공했습니다.
### 또다른 문제점🛠
- 우선 요구사항에서 화면양옆에 padding을 조금더 넉넉하게 주면 좋겟다! 라는 의견을 반영해서
`px-2  ==> px-4`로 수정했습니다.
### 마지막 수정사항👓
- ![bandicam-2024-05-16-18-07-16-378](https://github.com/mobi-projects/mobi-3rd-1-typescript/assets/144839872/e18d64a4-f72f-4edb-86af-641089527e5a)
- 저희 기존디자인에는 위에 `초록색 &  파란색`영역이 높이가 고정이 아니였습니다.
- 여기서 발생하는 문제점은 login <----> signUp 으로 전환시 높이가 변해서 ui변화가 심하다는 것입니다.
이는 사용자에게 좋은경험이 아니라생각해서 높이를 고정하는 방법으로 해결했습니다.
### 이제는 이렇게 보입니다🎁
- ![bandicam-2024-05-16-18-11-04-378](https://github.com/mobi-projects/mobi-3rd-1-typescript/assets/144839872/198af52f-7ad9-48ac-8bad-c1cd01caf1c2)

<br/>
<br/>

## ✅ 체크 리스트
<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.
    
    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!
    
    올바른 예)
    [x]
    
    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

-   [x] Main 브랜치 Pull 받기
-   [x] Issue 번호 설정 확인
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인




<br/>
<br/>

-----

#### 🙏 꼭 리뷰 남겨주세요.!!
- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
